### PR TITLE
Set default route for $NETWORK

### DIFF
--- a/fs-root/etc/cont-init.d/30-route
+++ b/fs-root/etc/cont-init.d/30-route
@@ -4,8 +4,8 @@
 if [ -n "$NET_LOCAL" ]; then
    gw="$(ip route | awk '/default/{print $3}')"
    for net in ${NET_LOCAL//[;,]/ }; do
-     echo "[$(date -Iseconds)] Enabling connection to network ${net}"
-      #ip route | grep -q "$net" || ip route add "$net" via "$gw" dev eth0
+      echo "[$(date -Iseconds)] Enabling connection to network ${net}"
+      ip route | grep -q "$net" || ip route add "$net" via "$gw" dev eth0
       iptables -A INPUT   -i eth0 -s "$net" -j ACCEPT
       iptables -A OUTPUT  -o eth0 -d "$net" -j ACCEPT
       iptables -A FORWARD -i eth0 -d "$net" -j ACCEPT


### PR DESCRIPTION
Same as in 30-route6.

Required to be able to use $NETWORK to access VPN-ized services from other hosts on the same network as the Docker host, which is very useful when running something from a NAS or personal server.